### PR TITLE
fix:マイグレーション依存関係を修正

### DIFF
--- a/todos/migrations/0008_auto_20250601_1900.py
+++ b/todos/migrations/0008_auto_20250601_1900.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+from django.contrib.auth import get_user_model
+
+def create_admin_user(apps, schema_editor):
+    User = get_user_model()
+    if not User.objects.filter(id=1).exists():
+        User.objects.create(
+            id=1,
+            username='admin',
+            email='admin@example.com',
+            is_staff=True,
+            is_superuser=True
+        )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('todos', '0007_todo_user'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_admin_user),
+    ]

--- a/todos/models.py
+++ b/todos/models.py
@@ -4,7 +4,7 @@ from django.conf import settings
 #Todoテーブル
 class Todo(models.Model):
     # ユーザーにタスクを紐づける。（ユーザー削除時は紐づいたタスクも同時に消去。）
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, default=1)
 
     title = models.CharField(max_length=200) #タスク名
     URGENCY_CHOICES = [


### PR DESCRIPTION
# 変更内容
- マイグレーションの依存関係の修正
- モデルの `user` フィールドにデフォルト値（ユーザーID=1）を設定
- 初期データとしてユーザーID=1のユーザーを作成する処理を追加

# 修正の背景
- マイグレーション実行時に `NULL→非NULL` への変更でエラーが発生していた
- デフォルトのユーザーを用意し、DBの整合性を確保する必要があったため

# 補足
- 他のアプリケーションコードには影響なし
- マイグレーションファイルの修正のみ